### PR TITLE
log template codegen

### DIFF
--- a/adapter/example-logger/README.md
+++ b/adapter/example-logger/README.md
@@ -1,0 +1,1 @@
+This is what we expect the adapter author to provide. They then run the mixer codegen CLI which spits out the contents of the autogen directory.

--- a/adapter/example-logger/config/config.proto
+++ b/adapter/example-logger/config/config.proto
@@ -1,0 +1,27 @@
+// COPY OF https://github.com/istio/mixer/blob/master/adapter/stdioLogger/config/config.proto
+
+syntax = "proto3";
+
+package adapter.stdioLogger.config;
+
+import "gogoproto/gogo.proto";
+
+option go_package = "config";
+option (gogoproto.goproto_getters_all) = false;
+option (gogoproto.equal_all) = false;
+option (gogoproto.gostring_all) = false;
+
+message Params {
+
+    // Stream is used to select between different logs output sinks.
+    enum Stream {
+        // STDERR refers to os.Stderr.
+        STDERR = 0;
+        // STDOUT refers to os.Stdout.
+        STDOUT = 1;
+    }
+
+    // Selects which standard stream to write to for log entries.
+    // STDERR is the default Stream.
+    Stream log_stream = 1;
+}

--- a/adapter/example-logger/logadapter.go
+++ b/adapter/example-logger/logadapter.go
@@ -1,0 +1,23 @@
+import "istio.io/autogen/mixer/aspect/log"
+
+func Register(r Registrar) {
+    r.registerLog(&adapter{})
+}
+
+struct adapter {}
+
+func (adapter) Close() error { return nil }
+func (adapter)  NewProcessor(Config, []*Template) (Processor, error) {
+    return &processor{}, nil
+}
+
+struct processor {
+    // state here
+}
+
+func (processor) Close() error { return nil }
+
+func (p processor) Process([]*Instance) error {
+    // do work logging the instances
+    return nil
+}

--- a/adapter/example-logger/template/log_template.proto
+++ b/adapter/example-logger/template/log_template.proto
@@ -1,0 +1,49 @@
+// COPY OF https://github.com/istio/api/blob/master/mixer/v1/config/descriptor/log_entry_descriptor.proto
+
+syntax = "proto3";
+
+package istio.mixer.adapter.log;
+
+import "mixer/v1/config/descriptor/value_type.proto";
+
+// Defines the format of a single log entry.
+message LogEntryTemplate {
+  // Required. The name of this descriptor.
+  string name = 1;
+
+  // Optional. A concise name for the log entry type, which can be displayed in
+  // user interfaces. Use sentence case without an ending period, for example
+  // "Request count".
+  string display_name = 2;
+
+  // Optional. A description of the log entry type, which can be used in documentation.
+  string description = 3;
+
+  // PayloadFormat details the currently supported logging payload formats.
+  // TEXT is the default payload format.
+  enum PayloadFormat {
+      // Invalid, default value.
+      PAYLOAD_FORMAT_UNSPECIFIED = 0;
+
+      // Indicates a payload format of raw text.
+      TEXT = 1;
+
+      // Indicates that the payload is a serialized JSON object.
+      JSON = 2;
+  }
+  // Required. Format of the value of the payload attribute.
+  PayloadFormat payload_format = 4;
+
+  // Required. The template that will be populated with labels at runtime to
+  // generate a log message; the labels describe the parameters for this template.
+  //
+  // The template strings must conform to go's text/template syntax.
+  // TODO: unify templates to use our expression language when its finalized
+  string log_template = 5;
+
+  // Dimensions describe the parameters of this log's template string. The log
+  // definition allows the user to map attribute expressions to actual values
+  // for these labels at run time; the result of the evaluation must be of the
+  // type described by the kind for each label.
+  map<string, ValueType> dimensions = 6;
+}

--- a/example-configs/log.yaml
+++ b/example-configs/log.yaml
@@ -1,0 +1,44 @@
+types:
+# yaml version of a log_template proto:
+- name: global/types/ApacheCommonLog-text
+  description: Apache common log template
+  template: istio.mixer.adapter.log.LogEntryTemplate # qualified proto name
+  payloadFormat: TEXT
+  logTemplate: '{{or (.originIp) "-"}} - {{or (.sourceUser) "-"}} [{{or (.timestamp.Format "02/Jan/2006:15:04:05 -0700") "-"}}] "{{or (.method) "-"}} {{or (.url) "-"}} {{or (.protocol) "-"}}" {{or (.responseCode) "-"}} {{or (.responseSize) "-"}}'
+  dimensions:
+    originIp: IP_ADDRESS
+    sourceUser: STRING
+    timestamp: TIMESTAMP
+    method: STRING
+    url: STRING
+    protocol: STRING
+    responseCode: INT64
+    responseSize: INT64
+
+constructors:
+- name: global/constructors/ApacheCommonLog-text
+  type: global/types/ApacheCommonLog-text
+  params:
+    logTemplate: # TODO: this is broken: we need a list of expressions to populate the template,
+                 # but we don't know we need to generate that in our proto definition. Not sure what
+                 # we need to do here.
+    dimensions:
+      originIp: "origin.ip"
+      sourceUser: "source.user"
+      timestamp: "request.time"
+      method: "request.method"
+      url: "request.url"
+      protocol: "request.scheme"
+      responseSize: "response.size"
+      responseCode: "response.code"
+
+handlers:
+- name: istio/mixer/example-logger
+  adapter: example-logger
+  logStream: STDOUT
+
+actions:
+- selector: true
+  handler: istio/mixer/example-logger
+  instances:
+  - global/constructors/ApacheCommonLog-text

--- a/generated/config/log.proto
+++ b/generated/config/log.proto
@@ -5,7 +5,7 @@ syntax = "proto3";
 
 package istio.mixer.adapter.log;
 
-message LogType {
+message LogConstructor {
   string name = 1;
 
   // The name of the template: istio.mixer.adapter.log.LogEntryTemplate.

--- a/generated/config/log_params.proto
+++ b/generated/config/log_params.proto
@@ -1,0 +1,24 @@
+// We need the params the adapter defines, but we also need metadata:
+// a name, adapter name, inlined w/ adapter params. Thinking here is
+// that they give us their input params, we autogen the final config.
+
+syntax = "proto3";
+
+package istio.mixer.adapter.log;
+
+message LogParams {
+    string name = 1;
+    string adapter = 2;
+
+    // Stream is used to select between different logs output sinks.
+    enum Stream {
+        // STDERR refers to os.Stderr.
+        STDERR = 0;
+        // STDOUT refers to os.Stdout.
+        STDOUT = 1;
+    }
+
+    // Selects which standard stream to write to for log entries.
+    // STDERR is the default Stream.
+    Stream log_stream = 3;
+}

--- a/generated/config/log_type.proto
+++ b/generated/config/log_type.proto
@@ -1,0 +1,25 @@
+// Take log_template, substitute ValueType->String to allow user to give us exprs.
+// Remove well-known descripton fields
+
+syntax = "proto3";
+
+package istio.mixer.adapter.log;
+
+message LogType {
+  string name = 1;
+
+  // The name of the template: istio.mixer.adapter.log.LogEntryTemplate.
+  // I think we might be able to get away with not having this field
+  string template = 2;
+
+  enum PayloadFormat {
+      PAYLOAD_FORMAT_UNSPECIFIED = 0;
+      TEXT = 1;
+      JSON = 2;
+  }
+  PayloadFormat payload_format = 4;
+
+  string log_template = 5;
+
+  map<string, string> dimensions = 6;
+}

--- a/generated/mixer/aspect/log.go
+++ b/generated/mixer/aspect/log.go
@@ -1,0 +1,35 @@
+package log
+
+import "io"
+import proto "istio.io/mixer/adapter/log"
+
+// TODO: how do we expose a validation interface? Could the validation interface be autogened too so it's well typed?
+
+// We're generating this, no need to use a proto.Message I think:
+// we can generate code w/ strong typing.
+type Config proto.LogParams
+
+type Adapter interface {
+  io.Closer
+
+  NewProcessor(Config, []*Template) (Processor, error)
+}
+
+type Processor interface {
+  io.Closer
+
+  // TODO: I still think we need the arity of the error to match the arity of the input...
+  Process([]*Instance) error
+}
+
+type Instance struct {
+    Template *proto.LogEntryTemplate
+    Name string
+    // Note that for logging specifically, this is different than how it works today:
+    // today the adapter never sees the template or the payload format, they only see
+    // a constructed object with the template already evaluated. But I don't know how
+    // we could automatically make that semantic change in our code gen.
+    PayloadFormat proto.LogEntryTemplate_PayloadFormat
+    LogTemplate string
+    Dimensions map[string]interface{}
+}


### PR DESCRIPTION
Here's my pass at what codegen might look like for the log template.

Unfortunately, there are a couple of spots where a straight-forward conversion breaks down for logs: specifically we ask for a log template, and we really need a `[]string` or `map<string, string>` to populate it, but we don't know that based on the proto types.